### PR TITLE
center main home text and add a border

### DIFF
--- a/TokenTestingBlazor/TokenTestingBlazor/TokenTestingBlazor.Client/Pages/Home.razor
+++ b/TokenTestingBlazor/TokenTestingBlazor/TokenTestingBlazor.Client/Pages/Home.razor
@@ -21,15 +21,19 @@ else
 
     @if (token is null || profileDTO is null)
     {
-        <h1>Canvas Assistant</h1>
+        <div class="homeWrapper">
+            <h1>Canvas Assistant</h1>
 
-        <h4>Now in Blazor!</h4>
+            <h4>Now in Blazor!</h4>
+        </div>
     }
     else
     {
-        <h1>@($"Welcome, {profileDTO.name}!")</h1>
+        <div class="homeWrapper">
+            <h1>@($"Welcome, {profileDTO.name}!")</h1>
 
-        <p>@($"User ID: {profileDTO.login_id}")</p>
+            <p>@($"User ID: {profileDTO.login_id}")</p>
+        </div>
     }
 }
 

--- a/TokenTestingBlazor/TokenTestingBlazor/TokenTestingBlazor.Client/Pages/Home.razor.css
+++ b/TokenTestingBlazor/TokenTestingBlazor/TokenTestingBlazor.Client/Pages/Home.razor.css
@@ -1,3 +1,11 @@
 ﻿h1 {
     color: black;
 }
+
+.homeWrapper {
+    width: 80%;
+    margin: auto;
+    padding: 15px;
+    border-radius: 10px;
+    border: 2px solid #A93238; 
+}


### PR DESCRIPTION
The current homepage has the text right up against the left side of the screen with no left margin. This adds a wrapper div that pushes the text rightward and also adds a border in the Davis Tech red-orange color for some minor styling to make it look nicer. 

Tested with a dummy html/css webpage:
![test welcome div](https://github.com/user-attachments/assets/75a7b673-bd6e-4d3d-9b54-3a7c20f27c0f)
