### PR TITLE
Fix app.css formatting

### DIFF
--- a/TokenTestingBlazor/TokenTestingBlazor/TokenTestingBlazor/wwwroot/app.css
+++ b/TokenTestingBlazor/TokenTestingBlazor/TokenTestingBlazor/wwwroot/app.css
@@ -42,9 +42,9 @@ h1:focus {
     color: white;
 }
 
-    .blazor-error-boundary::after {
-        content: "An error has occurred."
-    }
+.blazor-error-boundary::after {
+    content: "An error has occurred."
+}
 
 .darker-border-checkbox.form-check-input {
     border-color: #929292;


### PR DESCRIPTION
Fixed the `.blazor-error-boundary::after` indentation to be more consistent with the rest of the CSS